### PR TITLE
Dynamically setting the memory limit of the Nodejs VM

### DIFF
--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -28,4 +28,5 @@ RUN cd / && npm install --no-package-lock \
     && npm cache clean --force
 EXPOSE 8080
 ADD init.sh ./
+RUN chmod 777 ./init.sh
 CMD ["./init.sh"]

--- a/core/nodejs10Action/init.sh
+++ b/core/nodejs10Action/init.sh
@@ -29,7 +29,5 @@ then
     export NODE_OPTS="--max-old-space-size=${heap_size} $NODE_OPTS"
 fi
 
-echo  NODE_OPTS= $NODE_OPTS
-
 # See app.js --gc-global
 node $NODE_OPTS app.js

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -94,4 +94,5 @@ yauzl@2.7.0
 
 
 # See app.js
-CMD node --expose-gc app.js
+ADD init.sh ./
+CMD ["./init.sh"]

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -95,4 +95,5 @@ yauzl@2.7.0
 
 # See app.js
 ADD init.sh ./
+RUN chmod 777 ./init.sh
 CMD ["./init.sh"]

--- a/core/nodejs6Action/init.sh
+++ b/core/nodejs6Action/init.sh
@@ -29,7 +29,5 @@ then
     export NODE_OPTS="--max-old-space-size=${heap_size} $NODE_OPTS"
 fi
 
-echo  NODE_OPTS= $NODE_OPTS
-
 # See app.js --gc-global
 node $NODE_OPTS app.js

--- a/core/nodejs8Action/Dockerfile
+++ b/core/nodejs8Action/Dockerfile
@@ -28,4 +28,5 @@ RUN cd / && npm install --no-package-lock \
     && npm cache clean --force
 EXPOSE 8080
 ADD init.sh ./
+RUN chmod 777 ./init.sh
 CMD ["./init.sh"]

--- a/core/nodejs8Action/Dockerfile
+++ b/core/nodejs8Action/Dockerfile
@@ -27,4 +27,5 @@ COPY ./package.json /
 RUN cd / && npm install --no-package-lock \
     && npm cache clean --force
 EXPOSE 8080
-CMD node --expose-gc app.js
+ADD init.sh ./
+CMD ["./init.sh"]

--- a/core/nodejs8Action/init.sh
+++ b/core/nodejs8Action/init.sh
@@ -29,7 +29,5 @@ then
     export NODE_OPTS="--max-old-space-size=${heap_size} $NODE_OPTS"
 fi
 
-echo  NODE_OPTS= $NODE_OPTS
-
 # See app.js --gc-global
 node $NODE_OPTS app.js


### PR DESCRIPTION
The Nodejs VM in the container does not set the memory size limit, which causes the Nodejs VM to use the default size of memory. At this time, if the function sets the 256MB memory limit, the GC operation cannot be performed in time when the memory uses 256MB. The container is killed.
And in the case of the Prewarm container, the memory used by the last call cannot be recycled in time, so the new call available memory is drastically reduced.
I recommend dynamically setting the memory limit of the Nodejs VM by reading the Cgroup configuration during the container startup process.