### PR TITLE
marshaling zip actions from within runtime

### DIFF
--- a/core/nodejs10Action/knative/Dockerfile
+++ b/core/nodejs10Action/knative/Dockerfile
@@ -19,6 +19,7 @@ FROM node:10.15.3-stretch
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \
+    zip \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /nodejsAction

--- a/core/nodejs8Action/knative/Dockerfile
+++ b/core/nodejs8Action/knative/Dockerfile
@@ -19,6 +19,7 @@ FROM node:8.16.0
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \
+    zip \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /nodejsAction

--- a/core/nodejsActionBase/buildtemplate.yaml
+++ b/core/nodejsActionBase/buildtemplate.yaml
@@ -51,13 +51,21 @@ spec:
       if [ -z ${OW_PROJECT_URL} ]; then
         OW_ACTION_CODE="${OW_ACTION_CODE}"
       else
-        TEMPDIR="knative-"$((1 + RANDOM % 100))
-        TEMPFILE=`basename "${OW_PROJECT_URL}"`
-        mkdir $TEMPDIR
-        cd $TEMPDIR
-        wget -O $TEMPFILE "${OW_PROJECT_URL}"
-        OW_ACTION_CODE=`cat $TEMPFILE`
-        cd ..
+        if [ -f ${OW_PROJECT_URL} ]; then
+          if [ ${OW_ACTION_BINARY} ]; then
+            OW_ACTION_CODE=`base64 ${OW_PROJECT_URL}`
+          else
+            OW_ACTION_CODE=`cat ${OW_PROJECT_URL}`
+          fi
+        else
+            TEMPDIR="knative-"$((1 + RANDOM % 100))
+            TEMPFILE=`basename "${OW_PROJECT_URL}"`
+            mkdir $TEMPDIR
+            cd $TEMPDIR
+            wget -O $TEMPFILE "${OW_PROJECT_URL}"
+            OW_ACTION_CODE=`cat $TEMPFILE`
+            cd ..
+        fi
       fi
       cat <<EOF >> ${DOCKERFILE}
         ENV __OW_RUNTIME_DEBUG "${OW_RUNTIME_DEBUG}"
@@ -68,6 +76,7 @@ spec:
         ENV __OW_ACTION_BINARY "${OW_ACTION_BINARY}"
         ENV __OW_HTTP_METHODS "${OW_HTTP_METHODS}"
         ENV __OW_ACTION_RAW "${OW_ACTION_RAW}"
+        ENV __OW_PROJECT_URL "${OW_PROJECT_URL}"
       EOF
   - name: build-openwhisk-nodejs-runtime
     image: "gcr.io/kaniko-project/executor:latest"

--- a/core/nodejsActionBase/platform/knative.js
+++ b/core/nodejsActionBase/platform/knative.js
@@ -89,6 +89,7 @@ function createInitDataFromEnvironment(env) {
         // TODO: default to empty?
         initdata.actionName = (typeof env.__OW_ACTION_NAME === 'undefined') ? "" : env.__OW_ACTION_NAME;
         initdata.raw = (typeof env.__OW_ACTION_RAW === 'undefined') ? false : env.__OW_ACTION_RAW.toLowerCase() === "true";
+        initdata.url = (typeof env.__OW_PROJECT_URL === 'undefined') ? "" : env.__OW_PROJECT_URL;
 
         return initdata;
 
@@ -126,6 +127,9 @@ function preProcessInitData(initdata, valuedata, activationdata) {
                 } else {
                     throw ("Invalid Init. data; expected boolean for key 'raw'.");
                 }
+            }
+            if (initdata.url && typeof initdata.url === 'string') {
+                valuedata.url = initdata.url;
             }
 
             // Action name is a special case, as we have a key collision on "name" between init. data and request
@@ -231,6 +235,66 @@ function preProcessActivationData(env, activationdata) {
 }
 
 /**
+ * For actions having dependency on third party NPM modules, NodeJS runtime would
+ * install those NPM modules and package them as part of the action source using this function.
+ * In this function, runtime reads url from the initialization JSON payload,
+ * if the url points to an existing directory, run:
+ *      cd initdata.url && npm install --production && zip -r action.zip . && base64 action.zip
+ * Packaging actions as NodeJS module with NPM libraries are treated as zip actions by the runtime.
+ * Zipped actions must contain either package.json or index.js at the root.
+ * This validation is left to the user and not enforced while initializing the action.
+ */
+function marshalResources(initData, valueData) {
+    try {
+        // check if url is set and assigned some string value
+        if (typeof initData.url === "string" && initData.url !== undefined) {
+            const fs = require('fs');
+            if (fs.existsSync(initData.url)) {
+                const stats = fs.lstatSync(initData.url);
+                // check if specified url is an existing directory
+                if (stats.isDirectory()) {
+                    // import spawnSync routine from child_process NPM module
+                    // spawnSync spawns a new process using the given command and does not return until
+                    // the child process is fully closed/finished executing.
+                    // Note: Be very careful changing any of the child_process and spwanSync functionality
+                    const {spawnSync} = require('child_process'),
+                        npm = spawnSync('npm', ['install', '--production'], {cwd: initData.url});
+                    if (npm.status !== 0) {
+                        throw (npm.error);
+                    }
+
+                    var zipFile = "action.zip";
+                    // note here we are using same instance of spwanSync as we used for running npm install
+                    // to make sure the execution of zip command follows right after npm install closes (sequential)
+                    const compressFile = spawnSync('zip', ['-r', zipFile, '.'], {cwd: initData.url});
+                    if (compressFile.status !== 0) {
+                        throw (compressFile.error);
+                    }
+
+                    // and same here, making sure base64 command follows right after zip command finishes by
+                    // using the same spawnSync instance of child_process.
+                    const code = spawnSync('base64', [initData.url + '/' + zipFile]);
+                    if (code.status !== 0) {
+                        throw (code.error);
+                    }
+
+                    // assign base64 encoded zip file content to action code before initializing the action
+                    initData.code = code.stdout.toString().trim();
+                    valueData.code = initData.code;
+
+                    // mark this action as binary so that run routine can decode it appropriately
+                    initData.binary = true;
+                    valueData.binary = true;
+                }
+            }
+        }
+    } catch (e) {
+        console.error(e);
+        throw("Unable to marshall NPM resources: ");
+    }
+}
+
+/**
  * Pre-process the incoming http request data, moving it to where the
  * route handlers expect it to be for an openwhisk runtime.
  */
@@ -249,6 +313,8 @@ function preProcessRequest(req){
         if (hasInitData(req)) {
             preProcessInitData(initData, valueData, activationData);
         }
+
+        marshalResources(initData, valueData);
 
         if(hasActivationData(req)) {
             // process HTTP request header and body to make it available to function as parameter data
@@ -397,7 +463,7 @@ function PlatformKnativeImpl(platformFactory) {
             }
 
             // Different pre-processing logic based upon request data needed due Promise behavior
-            if(hasInitData(req) && hasActivationData(req)){
+            if(hasInitData(req) && hasActivationData(req)) {
                 // Request has both Init and Run (activation) data
                 preProcessRequest(req);
                 // Invoke the OW "init" entrypoint
@@ -462,6 +528,7 @@ function PlatformKnativeImpl(platformFactory) {
                     }
                 });
             }
+
         } catch (e) {
             res.status(500).json({error: "internal error during request processing."})
         }

--- a/tests/src/test/knative/zipaction/build.yaml.tmpl
+++ b/tests/src/test/knative/zipaction/build.yaml.tmpl
@@ -1,0 +1,29 @@
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: nodejs-10-package-npm
+spec:
+  serviceAccountName: openwhisk-runtime-builder
+  sources:
+    - name: runtime
+      git:
+        url: "https://github.com/apache/incubator-openwhisk-devtools.git"
+        revision: "master"
+    - name: application
+      targetPath: app
+      git:
+        url: "https://github.com/apache/incubator-openwhisk-test.git"
+        revision: "master"
+  template:
+    name: openwhisk-nodejs-runtime
+    arguments:
+      - name: TARGET_IMAGE_NAME
+        value: "docker.io/${DOCKER_USERNAME}/nodejs-10-package-npm"
+      - name: DOCKERFILE
+        value: "./knative-build/runtimes/javascript/Dockerfile"
+      - name: OW_ACTION_BINARY
+        value: "true"
+      - name: OW_ACTION_NAME
+        value: "nodejs-package-npm"
+      - name: OW_PROJECT_URL
+        value: "./app/packages/left-pad/"

--- a/tests/src/test/knative/zipaction/knative-data-init-run.json
+++ b/tests/src/test/knative/zipaction/knative-data-init-run.json
@@ -1,0 +1,20 @@
+{
+  "init": {
+    "name" : "nodejs-package-npm",
+    "main" : "main",
+    "binary": true,
+    "url" : "app/packages/left-pad/"
+  },
+  "activation": {
+    "namespace": "default",
+    "action_name": "nodejs-package-npm",
+    "api_host": "",
+    "api_key": "",
+    "activation_id": "",
+    "deadline": "4102498800000"
+  },
+  "value": {
+    "lines" : ["Hello","How are you?"]
+  }
+}
+

--- a/tests/src/test/knative/zipaction/knative-data-init.json
+++ b/tests/src/test/knative/zipaction/knative-data-init.json
@@ -1,0 +1,8 @@
+{
+  "init": {
+    "name" : "nodejs-package-npm",
+    "main" : "main",
+    "binary": true,
+    "url" : "app/packages/left-pad/"
+  }
+}

--- a/tests/src/test/knative/zipaction/knative-data-run.json
+++ b/tests/src/test/knative/zipaction/knative-data-run.json
@@ -1,0 +1,13 @@
+{
+  "activation": {
+    "namespace": "default",
+    "action_name": "nodejs-package-npm",
+    "api_host": "",
+    "api_key": "",
+    "activation_id": "",
+    "deadline": "4102498800000"
+  },
+  "value": {
+    "lines" : ["Hello","How are you?"]
+  }
+}

--- a/tests/src/test/knative/zipaction/service.yaml.tmpl
+++ b/tests/src/test/knative/zipaction/service.yaml.tmpl
@@ -1,0 +1,12 @@
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: nodejs-package-npm
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: docker.io/${DOCKER_USERNAME}/nodejs-10-package-npm


### PR DESCRIPTION
Automation to install NPM packages and create a .zip archive:

Install module dependencies using NPM:

```
npm install
```

Create a .zip archive containing all files (including all dependencies):

```
zip -r action.zip *
```

Decode .zip archive:

```
base64 -d action.zip
```