### PR TITLE
Export activation arguments to environment during initialization.

### DIFF
--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -17,10 +17,10 @@
 
 // __OW_ALLOW_CONCURRENT: see docs/concurrency.md
 var config = {
-        'port': 8080,
-        'apiHost': process.env.__OW_API_HOST,
-        'allowConcurrent': process.env.__OW_ALLOW_CONCURRENT,
-        'requestBodyLimit': "48mb"
+    'port': 8080,
+    'apiHost': process.env.__OW_API_HOST,
+    'allowConcurrent': process.env.__OW_ALLOW_CONCURRENT,
+    'requestBodyLimit': "48mb"
 };
 
 var bodyParser = require('body-parser');

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -160,6 +160,17 @@ function NodeActionService(config) {
     };
 
     function doInit(message) {
+        if (message.env && typeof message.env == 'object') {
+            Object.keys(message.env).forEach(k => {
+                let val = message.env[k];
+                if (typeof val !== 'object' || val == null) {
+                    process.env[k] = val ? val.toString() : "";
+                } else {
+                    process.env[k] = JSON.stringify(val);
+                }
+            });
+        }
+
         return initializeActionHandler(message)
             .then(handler => {
                 userCodeRunner = new NodeActionRunner(handler);

--- a/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
@@ -87,6 +87,25 @@ abstract class NodeJsActionContainerTests extends BasicActionRunnerTests with Ws
       """.stripMargin.trim)
   }
 
+  override val testEnvPartition = {
+    // the environment variables are ready at load time to ensure
+    // variables are already available in the runtime
+    TestConfig("""
+        |const envargs = {
+        |    "ARRAY": process.env.ARRAY,
+        |    "OBJECT": process.env.OBJECT,
+        |    "STRING": process.env.STRING,
+        |    "NUMBER": process.env.NUMBER,
+        |    "BOOL": process.env.BOOL,
+        |    "NULL": process.env.NULL
+        |}
+        |
+        |function main(args) {
+        |    return envargs
+        |}
+      """.stripMargin.trim)
+  }
+
   override val testInitCannotBeCalledMoreThanOnce = {
     TestConfig("""
         |function main(args) {

--- a/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
@@ -92,12 +92,8 @@ abstract class NodeJsActionContainerTests extends BasicActionRunnerTests with Ws
     // variables are already available in the runtime
     TestConfig("""
         |const envargs = {
-        |    "ARRAY": process.env.ARRAY,
-        |    "OBJECT": process.env.OBJECT,
-        |    "STRING": process.env.STRING,
-        |    "NUMBER": process.env.NUMBER,
-        |    "BOOL": process.env.BOOL,
-        |    "NULL": process.env.NULL
+        |    "SOME_VAR": process.env.SOME_VAR,
+        |    "ANOTHER_VAR": process.env.ANOTHER_VAR
         |}
         |
         |function main(args) {


### PR DESCRIPTION
This is part of the work related to https://github.com/apache/incubator-openwhisk/issues/4558 and depends on https://github.com/apache/incubator-openwhisk/pulls/4559.