### PR TITLE
Add redis and uuid npm modules

### DIFF
--- a/core/nodejs10Action/package.json
+++ b/core/nodejs10Action/package.json
@@ -11,6 +11,8 @@
     "openwhisk": "3.18.0",
     "body-parser": "1.18.3",
     "express": "4.16.4",
-    "serialize-error": "3.0.0"
+    "serialize-error": "3.0.0",
+    "redis": "2.8.0",
+    "uuid": "3.3.0"
   }
 }

--- a/core/nodejs12Action/package.json
+++ b/core/nodejs12Action/package.json
@@ -11,6 +11,8 @@
     "openwhisk": "3.18.0",
     "body-parser": "1.18.3",
     "express": "4.16.4",
-    "serialize-error": "3.0.0"
+    "serialize-error": "3.0.0",
+    "redis": "2.8.0",
+    "uuid": "3.3.0"
   }
 }

--- a/core/nodejs8Action/package.json
+++ b/core/nodejs8Action/package.json
@@ -11,6 +11,8 @@
     "openwhisk": "3.18.0",
     "body-parser": "1.18.2",
     "express": "4.16.2",
-    "serialize-error": "3.0.0"
+    "serialize-error": "3.0.0",
+    "redis": "2.8.0",
+    "uuid": "3.3.0"
   }
 }

--- a/core/nodejsActionBase/package.json
+++ b/core/nodejsActionBase/package.json
@@ -15,6 +15,8 @@
     "express": "4.14.0",
     "log4js": "0.6.38",
     "request": "2.79.0",
-    "serialize-error": "3.0.0"
+    "serialize-error": "3.0.0",
+    "redis": "2.8.0",
+    "uuid": "3.3.0"
   }
 }


### PR DESCRIPTION
### Description
This PR fixes composer, which requires `redis` and `uuid` modules.
See the [discussion](https://lists.apache.org/thread.html/beda24f3568164b5f750b3a91915ec9e275d878ae0e5c008cd0fbf3d@%3Cdev.openwhisk.apache.org%3E) on the dev list for more details. 

### Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).