### PR TITLE
bump node 8,10,12 base docker images to consume upstream security fixes

### DIFF
--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:10.16.3-stretch
+FROM node:10.18.1-stretch
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \

--- a/core/nodejs12Action/Dockerfile
+++ b/core/nodejs12Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:12.8.1-stretch
+FROM node:12.14.1-stretch
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \

--- a/core/nodejs8Action/Dockerfile
+++ b/core/nodejs8Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:8.16.1
+FROM node:8.17.0
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \


### PR DESCRIPTION
8.17.0
10.18.1
12.14.1
