### PR TITLE
release prep

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache OpenWhisk Runtime Node.js
-Copyright 2016-2019 The Apache Software Foundation
+Copyright 2016-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/core/nodejs10Action/CHANGELOG.md
+++ b/core/nodejs10Action/CHANGELOG.md
@@ -19,7 +19,16 @@
 
 # NodeJS 10 OpenWhisk Runtime Container
 
-## Apache 1.13 (next release)
+## Apache 1.15
+Changes:
+  - Update Node.js
+  - Update openwhisk npm package
+  - Support for __OW_ACTION_VERSION (openwhisk/4761)
+
+Node.js version = [10.19.0](https://nodejs.org/en/blog/release/v10.19.0/)
+openwhisk version = [openwhisk v3.21.1](https://www.npmjs.com/package/openwhisk)
+
+## Apache 1.13
 Changes:
 - Initial version with NodejS10 LTS
 - Node.js version = [10.16.3](https://nodejs.org/en/blog/release/v10.16.3/)

--- a/core/nodejs10Action/package.json
+++ b/core/nodejs10Action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "openwhisk": "3.18.0",
+    "openwhisk": "3.21.1",
     "body-parser": "1.18.3",
     "express": "4.16.4",
     "serialize-error": "3.0.0",

--- a/core/nodejs12Action/CHANGELOG.md
+++ b/core/nodejs12Action/CHANGELOG.md
@@ -19,7 +19,16 @@
 
 # NodeJS 12 OpenWhisk Runtime Container
 
-## Apache 1.14 (next release)
+## Apache 1.15
+Changes:
+  - Update Node.js
+  - Update openwhisk npm package
+  - Support for __OW_ACTION_VERSION (openwhisk/4761)
+
+Node.js version = [12.15.0](https://nodejs.org/en/blog/release/v12.15.0/)
+openwhisk version = [openwhisk v3.21.1](https://www.npmjs.com/package/openwhisk)
+
+## Apache 1.14
 Changes:
 - Adding Nodejs version 12
 - Node.js version = [12.8.1](https://nodejs.org/en/blog/release/v12.8.1/)

--- a/core/nodejs12Action/package.json
+++ b/core/nodejs12Action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "openwhisk": "3.18.0",
+    "openwhisk": "3.21.1",
     "body-parser": "1.18.3",
     "express": "4.16.4",
     "serialize-error": "3.0.0",

--- a/core/nodejs6Action/CHANGELOG.md
+++ b/core/nodejs6Action/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # NodeJS 6 OpenWhisk Runtime Container
 
-## Apache 1.13 (next release)
+## Apache 1.13
 Changes:
 - Update Node.js
 - Update openwhisk npm package

--- a/core/nodejs8Action/CHANGELOG.md
+++ b/core/nodejs8Action/CHANGELOG.md
@@ -19,7 +19,16 @@
 
 # NodeJS 8 OpenWhisk Runtime Container
 
-## Apache 1.13 (next release)
+## Apache 1.15
+Changes:
+  - Update Node.js
+  - Update openwhisk npm package
+  - Support for __OW_ACTION_VERSION (openwhisk/4761)
+
+Node.js version = [8.17.0](https://nodejs.org/en/blog/release/v8.17.0/)
+openwhisk version = [openwhisk v3.21.1](https://www.npmjs.com/package/openwhisk)
+
+## Apache 1.13
 Changes:
 - Update Node.js
 - Update openwhisk npm package

--- a/core/nodejs8Action/package.json
+++ b/core/nodejs8Action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "openwhisk": "3.18.0",
+    "openwhisk": "3.21.1",
     "body-parser": "1.18.2",
     "express": "4.16.2",
     "serialize-error": "3.0.0",


### PR DESCRIPTION
bump openwhisk-client-js version to 3.21.1
update CHANGELOG.md for node 8,10,12
update end year in NOTICE