### PR TITLE
Add http client modules to nodejs dependency

### DIFF
--- a/core/nodejs10Action/package.json
+++ b/core/nodejs10Action/package.json
@@ -13,6 +13,8 @@
     "express": "4.16.4",
     "serialize-error": "3.0.0",
     "redis": "2.8.0",
-    "uuid": "3.3.0"
+    "uuid": "3.3.0",
+    "request": "2.88.2",
+    "request-promise": "4.2.5"
   }
 }

--- a/core/nodejs12Action/package.json
+++ b/core/nodejs12Action/package.json
@@ -13,6 +13,8 @@
     "express": "4.16.4",
     "serialize-error": "3.0.0",
     "redis": "2.8.0",
-    "uuid": "3.3.0"
+    "uuid": "3.3.0",
+    "request": "2.88.2",
+    "request-promise": "4.2.5"
   }
 }

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -68,8 +68,8 @@ pkgcloud@1.4.0 \
 process@0.11.9 \
 pug@">=2.0.0-beta6 <2.0.1" \
 redis@2.6.3 \
-request@2.79.0 \
-request-promise@4.1.1 \
+request@2.88.2 \
+request-promise@4.2.5 \
 rimraf@2.5.4 \
 semver@5.3.0 \
 sendgrid@4.7.1 \

--- a/core/nodejs8Action/package.json
+++ b/core/nodejs8Action/package.json
@@ -13,6 +13,8 @@
     "express": "4.16.2",
     "serialize-error": "3.0.0",
     "redis": "2.8.0",
-    "uuid": "3.3.0"
+    "uuid": "3.3.0",
+    "request": "2.88.2",
+    "request-promise": "4.2.5"
   }
 }


### PR DESCRIPTION
[With the default nodejs version of the Alarm package updated to 10](https://github.com/apache/openwhisk-package-alarms/pull/204), other nodejs versions also needed the dependencies required by the alarm package. In particular, the modules associated with the http client are frequently used, so I think it would be good to add them to the default runtime.