### PR TITLE
updating the package.json path

### DIFF
--- a/core/nodejs10Action/knative/Dockerfile
+++ b/core/nodejs10Action/knative/Dockerfile
@@ -30,7 +30,7 @@ COPY ./core/nodejsActionBase/platform/*.js ./platform/
 COPY . .
 # COPY the package.json to root container, so we can install npm packages a level up from user's packages,
 # so user's packages take precedence
-COPY ./core/nodejs10Action/package.json /
+COPY ./core/nodejsActionBase/package.json /
 RUN cd / && npm install --no-package-lock \
     && npm cache clean --force
 EXPOSE 8080


### PR DESCRIPTION
`package.json` was dropped from the version specific dir in PR #171. Reflecting the same change in Dockefile which is being used by Knative.