### PR TITLE
Update the NodeJs runtimes to gather fixes

### DIFF
--- a/core/nodejs10Action/CHANGELOG.md
+++ b/core/nodejs10Action/CHANGELOG.md
@@ -18,7 +18,7 @@
 -->
 
 # NodeJS 10 OpenWhisk Runtime Container
-## Next release 
+## Next release
 Node.js version = [10.22.1](https://nodejs.org/en/blog/release/v10.22.1/)
 
 ## Apache 1.16

--- a/core/nodejs10Action/CHANGELOG.md
+++ b/core/nodejs10Action/CHANGELOG.md
@@ -18,6 +18,8 @@
 -->
 
 # NodeJS 10 OpenWhisk Runtime Container
+## Next release 
+Node.js version = [10.22.1](https://nodejs.org/en/blog/release/v10.22.1/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:10.21.0-stretch
+FROM node:10.22.1-stretch
 
 # Initial update and some basics.
 #

--- a/core/nodejs12Action/CHANGELOG.md
+++ b/core/nodejs12Action/CHANGELOG.md
@@ -18,6 +18,8 @@
 -->
 
 # NodeJS 12 OpenWhisk Runtime Container
+## Next release
+Node.js version = [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs12Action/Dockerfile
+++ b/core/nodejs12Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:12.18.2-stretch
+FROM node:12.18.4-stretch
 
 # Initial update and some basics.
 #

--- a/core/nodejs14Action/CHANGELOG.md
+++ b/core/nodejs14Action/CHANGELOG.md
@@ -18,6 +18,8 @@
 -->
 
 # NodeJS 14 OpenWhisk Runtime Container
+## Next release
+Node.js version = [14.11.0](https://nodejs.org/en/blog/release/v14.11.0/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:14.4.0-stretch
+FROM node:14.11.0-stretch
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
Update the NodeJS to gather fixes
- Node.js v10.22.1 
- Node.js v12.18.4 
- Node.js v14.11.0
