### PR TITLE
use lts-stretch (not stretch) as base image of nodejsActionBase

### DIFF
--- a/core/nodejsActionBase/Dockerfile
+++ b/core/nodejsActionBase/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:stretch
+FROM node:lts-stretch
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
stretch switched to node 15.1 about 24 hours ago.  This causes the build to fail (which we need to look into at some point), but as a general rule we should probably be using the most recent lts version, not the most recent dev version when building the base image.

For the record, the build error with node 15.1 was:

```
0 verbose cli [
0 verbose cli   '/usr/local/bin/node',
0 verbose cli   '/usr/local/bin/npm',
0 verbose cli   'install',
0 verbose cli   '--no-package-lock',
0 verbose cli   '--production'
0 verbose cli ]
1 info using npm@7.0.8
2 info using node@v15.1.0
3 timing config:load:defaults Completed in 2ms
4 timing config:load:file:/usr/local/lib/node_modules/npm/npmrc Completed in 1ms
5 timing config:load:builtin Completed in 1ms
6 timing config:load:cli Completed in 4ms
7 timing config:load:env Completed in 0ms
8 timing config:load:file:/.npmrc Completed in 0ms
9 timing config:load:project Completed in 2ms
10 timing config:load:file:/root/.npmrc Completed in 0ms
11 timing config:load:user Completed in 0ms
12 timing config:load:file:/usr/local/etc/npmrc Completed in 0ms
13 timing config:load:global Completed in 1ms
14 timing config:load:cafile Completed in 0ms
15 timing config:load:validate Completed in 0ms
16 timing config:load:setUserAgent Completed in 0ms
17 timing config:load:setEnvs Completed in 2ms
18 timing config:load Completed in 13ms
19 verbose npm-session b04d70d20b8e1062
20 timing npm:load Completed in 30ms
21 http fetch GET 200 https://registry.npmjs.org/npm 603ms
22 http fetch GET 304 https://registry.npmjs.org/npm 76ms (from cache)
23 timing arborist:ctor Completed in 2ms
24 timing arborist:ctor Completed in 0ms
25 timing command:install Completed in 48ms
26 verbose stack RangeError: Maximum call stack size exceeded
26 verbose stack     at Node.get parent [as parent] (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:718:5)
26 verbose stack     at Node.get resolveParent [as resolveParent] (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:976:17)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:983:32)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
26 verbose stack     at Node.resolve (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/node.js:985:28)
27 verbose cwd /root
28 verbose Linux 5.4.39-linuxkit
29 verbose argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "--no-package-lock" "--production"
30 verbose node v15.1.0
31 verbose npm  v7.0.8
32 error Maximum call stack size exceeded
```