### PR TITLE
Gather NodeJS fixes

### DIFF
--- a/core/nodejs10Action/CHANGELOG.md
+++ b/core/nodejs10Action/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # NodeJS 10 OpenWhisk Runtime Container
 ## Next release
-Node.js version = [10.22.1](https://nodejs.org/en/blog/release/v10.22.1/)
+Node.js version = [10.23.0](https://nodejs.org/en/blog/release/v10.23.0/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:10.22.1-stretch
+FROM node:10.23.0-stretch
 
 # Initial update and some basics.
 #

--- a/core/nodejs12Action/CHANGELOG.md
+++ b/core/nodejs12Action/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # NodeJS 12 OpenWhisk Runtime Container
 ## Next release
-Node.js version = [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/)
+Node.js version = [12.19.1](https://nodejs.org/en/blog/release/v12.19.1/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs12Action/Dockerfile
+++ b/core/nodejs12Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:12.18.4-stretch
+FROM node:12.19.1-stretch
 
 # Initial update and some basics.
 #

--- a/core/nodejs14Action/CHANGELOG.md
+++ b/core/nodejs14Action/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # NodeJS 14 OpenWhisk Runtime Container
 ## Next release
-Node.js version = [14.11.0](https://nodejs.org/en/blog/release/v14.11.0/)
+Node.js version = [14.15.1](https://nodejs.org/en/blog/release/v14.15.1/)
 
 ## Apache 1.16
 Changes:

--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:14.11.0-stretch
+FROM node:14.15.1-stretch
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
Upate runtimes to 
v14.15.1
v12.19.1
v10.23.0
to pick up fixes