### PR TITLE
Introduce tutorial to deploy NodeJS runtime locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ default.props
 .ant-targets-build.xml
 /results/
 /logs/
+/build/
 /config/custom-config.xml
 results
 *.retry


### PR DESCRIPTION
The introduced tutorial uses Docker and a tranfer data
tool (e.g. curl, wget or Postman). A summary of the tutorial
steps are:

1. Create docker container based on core/nodejs14Action
   Dockerfile
2. Deploy/run the container locally
3. Create function that resides in a json file
4. Initialize the function against the deployed container
   using either curl, wget or Postman
5. Call/trigger function using either curl, wget or Postman

Signed-off-by: Igor Braga <higorb1@gmail.com>