### PR TITLE
Constraint all transitive akka-* dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -35,8 +35,13 @@ gradle.ext.openwhisk = [
 
 gradle.ext.scala = [
     version: '2.12.7',
+    depVersion  : '2.12',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
+
+
+gradle.ext.akka = [version : '2.6.12']
+gradle.ext.akka_http = [version : '10.2.4']
 
 gradle.ext.scalafmt = [
     version: '1.5.0',

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,7 +34,7 @@ gradle.ext.openwhisk = [
 ]
 
 gradle.ext.scala = [
-    version: '2.12.7',
+    version: '2.12.10',
     depVersion  : '2.12',
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -24,6 +24,25 @@ repositories {
     mavenLocal()
 }
 
+pluginManager.withPlugin('scala') {
+    // Constraint all transitive akka-* dependencies to the one we want to use to avoid issues.
+    // List generated via
+    // ./gradlew :test:dependencies | grep -o 'akka-.*_' | cut -c 6- | rev | cut -c 2- | rev | sort -u
+    def cons = project.getDependencies().getConstraints()
+    def akka = ['akka-actor', 'akka-cluster', 'akka-cluster-metrics', 'akka-cluster-tools', 'akka-coordination',
+                'akka-discovery', 'akka-distributed-data', 'akka-protobuf', 'akka-remote', 'akka-slf4j',
+                'akka-stream', 'akka-stream-testkit', 'akka-testkit']
+    def akkaHttp = ['akka-http', 'akka-http-core', 'akka-http-spray-json', 'akka-http-testkit', 'akka-http-xml',
+                    'akka-parsing', 'akka-http2-support']
+
+    akka.forEach {
+        cons.add('compile', "com.typesafe.akka:${it}_${gradle.scala.depVersion}:${gradle.akka.version}")
+    }
+    akkaHttp.forEach {
+        cons.add('compile', "com.typesafe.akka:${it}_${gradle.scala.depVersion}:${gradle.akka_http.version}")
+    }
+}
+
 tasks.withType(Test) {
     testLogging {
         events "passed", "skipped", "failed"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -24,25 +24,6 @@ repositories {
     mavenLocal()
 }
 
-pluginManager.withPlugin('scala') {
-    // Constraint all transitive akka-* dependencies to the one we want to use to avoid issues.
-    // List generated via
-    // ./gradlew :test:dependencies | grep -o 'akka-.*_' | cut -c 6- | rev | cut -c 2- | rev | sort -u
-    def cons = project.getDependencies().getConstraints()
-    def akka = ['akka-actor', 'akka-cluster', 'akka-cluster-metrics', 'akka-cluster-tools', 'akka-coordination',
-                'akka-discovery', 'akka-distributed-data', 'akka-protobuf', 'akka-remote', 'akka-slf4j',
-                'akka-stream', 'akka-stream-testkit', 'akka-testkit']
-    def akkaHttp = ['akka-http', 'akka-http-core', 'akka-http-spray-json', 'akka-http-testkit', 'akka-http-xml',
-                    'akka-parsing', 'akka-http2-support']
-
-    akka.forEach {
-        cons.add('compile', "com.typesafe.akka:${it}_${gradle.scala.depVersion}:${gradle.akka.version}")
-    }
-    akkaHttp.forEach {
-        cons.add('compile', "com.typesafe.akka:${it}_${gradle.scala.depVersion}:${gradle.akka_http.version}")
-    }
-}
-
 tasks.withType(Test) {
     testLogging {
         events "passed", "skipped", "failed"
@@ -56,6 +37,15 @@ dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:tests"
     compile "org.apache.openwhisk:openwhisk-tests:${gradle.openwhisk.version}:test-sources"
+    implementation group: 'com.typesafe.akka', name: "akka-http2-support_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-http-xml_${gradle.scala.depVersion}", version: "${gradle.akka_http.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-discovery_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-protobuf_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-remote_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-cluster-metrics_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-cluster_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-cluster-tools_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
+    implementation group: 'com.typesafe.akka', name: "akka-distributed-data_${gradle.scala.depVersion}", version: "${gradle.akka.version}"
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
This may fix the build issue with the Akka family.
