### PR TITLE
Update Node to 14.17.5 and 12.22.5.

### DIFF
--- a/core/nodejs12Action/CHANGELOG.md
+++ b/core/nodejs12Action/CHANGELOG.md
@@ -19,6 +19,12 @@
 
 # NodeJS 12 OpenWhisk Runtime Container
 
+# Next Release
+  - Update Node to 14.17.5 and 12.22.5 (#201)
+
+Node.js version = [12.22.5](https://nodejs.org/en/blog/release/v12.22.5/)
+OpenWhisk version = [OpenWhisk v3.21.4](https://www.npmjs.com/package/openwhisk)
+
 # Apache 1.19
   - Remove Node.js 10 support
   - Update Node to 14.17.2 and 12.22.2 (#197)

--- a/core/nodejs12Action/Dockerfile
+++ b/core/nodejs12Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:12.22.2-stretch
+FROM node:12.22.5-stretch
 
 # Initial update and some basics.
 #

--- a/core/nodejs14Action/CHANGELOG.md
+++ b/core/nodejs14Action/CHANGELOG.md
@@ -19,6 +19,12 @@
 
 # NodeJS 14 OpenWhisk Runtime Container
 
+# Next Release
+  - Update Node to 14.17.5 and 12.22.5 (#201)
+
+Node.js version = [14.17.5](https://nodejs.org/en/blog/release/v14.17.5/)
+OpenWhisk version = [OpenWhisk v3.21.4](https://www.npmjs.com/package/openwhisk)
+
 # Apache 1.19
   - Remove Node.js 10 support
   - Update Node to 14.17.2 and 12.22.2 (#197)

--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:14.17.2-stretch
+FROM node:14.17.5-stretch
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
- Update Node to 14.17.5 and 12.22.5 to get latest security fixes.