### PR TITLE
Update nodejs16 base image to stay up do date

### DIFF
--- a/core/nodejs16Action/Dockerfile
+++ b/core/nodejs16Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:16.13-stretch
+FROM node:16.14-bullseye
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
Update to latest Debian release as Stretch support runs out this year