### PR TITLE
Update package.json packages to latest version

### DIFF
--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -41,7 +41,7 @@ var service = require('./src/service').getService(config);
  * setup a middleware layer to restrict the request body size
  * this middleware is called every time a request is sent to the server
  */
-app.use(bodyParser.json({ limit: config.requestBodyLimit }));
+app.use(express.json({ limit: config.requestBodyLimit }));
 
 // identify the target Serverless platform
 const platformFactory = require('./platform/platform.js');

--- a/core/nodejsActionBase/package.json
+++ b/core/nodejsActionBase/package.json
@@ -8,21 +8,20 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "btoa": "1.1.2",
+    "btoa": "1.2.1",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
-    "request": "2.79.0"
+    "request": "2.88.2"
   },
   "dependencies": {
-    "openwhisk": "3.21.4",
-    "body-parser": "1.18.3",
-    "express": "4.16.4",
-    "serialize-error": "3.0.0",
-    "redis": "2.8.0",
-    "uuid": "3.3.0"
+    "openwhisk": "3.21.6",
+    "express": "4.17.3",
+    "serialize-error": "9.1.0",
+    "redis": "4.0.4",
+    "uuid": "8.3.2"
   }
 }

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -104,8 +104,17 @@ class NodeActionRunner {
             if (!error) {
                 resolve({error: {}});
             } else {
-                const serializeError = require('serialize-error');
-                resolve({error: serializeError(error)});
+                // Replace unsupported require statement with
+                // dynamically import npm serialize-error package returning a promise
+                import('serialize-error')
+                .then(module => {
+                    // if serialize-error is imported correctly the function resolves with a serializedError
+                    resolve({error: module.serializeError(error)});
+                })
+                .catch(err => {
+                    // When there is an error to serialize the error object, resolve with the error message
+                    resolve({error: err.message });
+                });
             }
         });
     }


### PR DESCRIPTION
adapt serialize-error to use a dynamic import instead of deprecated require
use express.json to replace bodyParser.json (remove bodyparser)