### PR TITLE
Install zip

### DIFF
--- a/core/nodejs16Action/Dockerfile
+++ b/core/nodejs16Action/Dockerfile
@@ -22,6 +22,7 @@ FROM node:16.14-bullseye
 RUN apt-get update && apt-get install -y \
     imagemagick \
     graphicsmagick \
+    zip \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is for convenience so customers can package their actions inside of the runtime.