### PR TITLE
Update Nodejs 16 base image

### DIFF
--- a/core/nodejs16Action/CHANGELOG.md
+++ b/core/nodejs16Action/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 # NodeJS 16 OpenWhisk Runtime Container
 
+# Next release
+  - use node:16-bullseye as base image to automatically get vulnerability fixes
+
 # Apache 1.20
   - Initial release with support for Node.js v1.16
 

--- a/core/nodejs16Action/Dockerfile
+++ b/core/nodejs16Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:16.15-bullseye
+FROM node:16-bullseye
 
 # Initial update and some basics.
 #


### PR DESCRIPTION
Setting Nodejs 16 image to `node:16-bullseye` to get latest vulnerability fixes