### PR TITLE
Update travis build vm dist form xenial to focal 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: xenial
+dist: focal
 jdk: openjdk8
 language: java
 services:


### PR DESCRIPTION
This bings the machines to the build VM to a more up to date Ubuntu version which should also reduce the risk of loosing support for the version