### PR TITLE
Update travis build vm dist form xenial to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 #
 
 sudo: required
-dist: xenial
+dist: focal
 jdk: openjdk8
 language: java
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 
 sudo: required
 dist: focal
-jdk: openjdk8
+jdk: openjdk11
 language: java
 services:
   - docker


### PR DESCRIPTION
This bings the machines to the build vm to a more up to date ubuntu version which should also reduce the risk of loosing support for the version

and update build java version to 11