### PR TITLE
GitHub action to replace Travis CI build/test/publish logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Continuous Integration
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout runtime repo
+        uses: actions/checkout@v3
+        with:
+          path: runtime
+      - name: Scan Code
+        uses: apache/openwhisk-utilities/scancode@master
+      - name: Checkout OpenWhisk core repo
+        uses: actions/checkout@v3
+        with:
+          repository: apache/openwhisk
+          path: core
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Compile and Install Core OpenWhisk
+        working-directory: core
+        run: |
+          ./gradlew :tests:compileTestScala
+          ./gradlew install
+      - name: Build Runtime
+        working-directory: runtime
+        run: |
+          ./gradlew distDocker
+      - name: Test Runtime
+        working-directory: runtime
+        run: |
+          ./gradlew :tests:checkScalafmtAll
+          ./gradlew :tests:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,22 +17,35 @@
 #
 
 name: Continuous Integration
+
 on:
   push:
     branches: [ master ]
+    tags: [ '*' ]
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 1 * * 1,3,5'
+
+permissions: read-all
+
 jobs:
   ci:
     runs-on: ubuntu-22.04
+    env:
+      PUSH_NIGHTLY: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master' }}
+      PUSH_RELEASE: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     steps:
+      # Checkout just this repo and run scanCode before we do anything else
       - name: Checkout runtime repo
         uses: actions/checkout@v3
         with:
           path: runtime
       - name: Scan Code
         uses: apache/openwhisk-utilities/scancode@master
+
+      # Install core OpenWhisk artifacts needed to build/test anything else
       - name: Checkout OpenWhisk core repo
         uses: actions/checkout@v3
         with:
@@ -48,12 +61,45 @@ jobs:
         run: |
           ./gradlew :tests:compileTestScala
           ./gradlew install
+
+      # Build this repository
       - name: Build Runtime
         working-directory: runtime
         run: |
           ./gradlew distDocker
+
+      # Test this repository
       - name: Test Runtime
         working-directory: runtime
         run: |
           ./gradlew :tests:checkScalafmtAll
           ./gradlew :tests:test
+
+      # Conditionally publish runtime images to DockerHub
+      # Important: naming convention for release tags is runtime@version
+      - name: Docker Login
+        if: ${{ env.PUSH_NIGHTLY  == 'true' || env.PUSH_RELEASE == 'true' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_OPENWHISK }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_OPENWHISK }}
+      - name: Push Nightly Images
+        if: ${{ env.PUSH_NIGHTLY  == 'true' }}
+        working-directory: runtime
+        run: |
+          SHORT_COMMIT=$(git rev-parse --short "$GITHUB_SHA")
+          ./gradlew :core:nodejs14Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:nodejs14Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+          ./gradlew :core:nodejs16Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:nodejs16Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+          ./gradlew :core:nodejs18Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:nodejs18Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+          ./gradlew :core:typescript37Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=nightly
+          ./gradlew :core:typescript37Action:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$SHORT_COMMIT
+      - name: Push Release Images
+        if: ${{ env.PUSH_RELEASE == 'true' }}
+        working-directory: runtime
+        run: |
+          RUNTIME_NAME=${GITHUB_REF_NAME%@*}
+          IMAGE_TAG=${GITHUB_REF_NAME##*@}
+          ./gradlew :core:$RUNTIME_NAME:distDocker -PdockerRegistry=docker.io -PdockerImagePrefix=openwhisk -PdockerImageTag=$IMAGE_TAG


### PR DESCRIPTION
I believe this is now a full replacement for our existing Travis CI based workflow for this repository. 

I've been testing on my fork and it looks good.  Assuming it also looks good on the real repo (including the cron job to drive publishing of new images a few times a week), we should be able to fairly easily adapt the workflow file to the rest of our runtime repos.

I decided to port as much of the workflow as possible to a native GHA idioms and not just invoke our legacy scripts (which had accumulated a fair amount of historical baggage). 