### PR TITLE
Add functionality to install modules during init

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -49,11 +49,11 @@ function initializeActionHandler(message) {
                 // install npm modules during init if source code zip doesn´t containt them
                 // check if package.json exists and node_modules don`t
                 if (fs.existsSync('package.json') && !fs.existsSync('./node_modules/')) {
-                    var package_json = require('package.json'); 
+                    var package_json = require('package.json');
                     if (package_json.hasOwnProperty('dependencies')) {
                         if (Object.keys(package_json.dependencies).length > 0) {
                             exec("npm install")
-                        } 
+                        }
                     }
                 }
 

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -46,6 +46,22 @@ function initializeActionHandler(message) {
                     return Promise.reject('Zipped actions must contain either package.json or index.js at the root.');
                 }
 
+                // install npm modules during init if source code zip doesn´t containt them
+                // check if package.json exists and node_modules don`t
+                if (fs.existsSync('package.json') && !fs.existsSync('./node_modules')) {
+                    let folderfiles = fs.readdirSync('./')
+                    console.log(folderfiles)
+                    let jsfilePaths = folderfiles
+                        .filter(file=> file.endsWith('.js'))
+                        .map(file=> path.resolve(__dirname, file))
+                    // check to make sure that at least 1 javascript source file exists
+                    if (jsfilePaths.length > 0) {
+                        exec("npm install")
+                    } else {
+                        return Promise.reject('There is no javascript source code.');
+                    }
+                }
+
                 //  The module to require.
                 let whatToRequire = index !== undefined ? path.join(moduleDir, index) : moduleDir;
                 let handler = eval('require("' + whatToRequire + '").' + main);

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -48,17 +48,12 @@ function initializeActionHandler(message) {
 
                 // install npm modules during init if source code zip doesn´t containt them
                 // check if package.json exists and node_modules don`t
-                if (fs.existsSync('package.json') && !fs.existsSync('./node_modules')) {
-                    let folderfiles = fs.readdirSync('./')
-                    console.log(folderfiles)
-                    let jsfilePaths = folderfiles
-                        .filter(file=> file.endsWith('.js'))
-                        .map(file=> path.resolve(__dirname, file))
-                    // check to make sure that at least 1 javascript source file exists
-                    if (jsfilePaths.length > 0) {
-                        exec("npm install")
-                    } else {
-                        return Promise.reject('There is no javascript source code.');
+                if (fs.existsSync('package.json') && !fs.existsSync('./node_modules/')) {
+                    var package_json = require('package.json'); 
+                    if (package_json.hasOwnProperty('dependencies')) {
+                        if (Object.keys(package_json.dependencies).length > 0) {
+                            exec("npm install")
+                        } 
                     }
                 }
 

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -49,7 +49,7 @@ function initializeActionHandler(message) {
                 // install npm modules during init if source code zip doesn´t containt them
                 // check if package.json exists and node_modules don`t
                 if (fs.existsSync('package.json') && !fs.existsSync('./node_modules/')) {
-                    var package_json = require('package.json');
+                    var package_json = JSON.parse(fs.readFileSync('package.json', 'utf8'));
                     if (package_json.hasOwnProperty('dependencies')) {
                         if (Object.keys(package_json.dependencies).length > 0) {
                             exec("npm install")


### PR DESCRIPTION
Install modules specified in package.json during initialisation as a alternative to packageing them. Detect if the node_modules directory is  missing and installes the node modules.