### PR TITLE
Make 'npm install' during init configurable.

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -50,16 +50,24 @@ function initializeActionHandler(message) {
                     return Promise.reject('Zipped actions must contain either package.json or index.js at the root.');
                 }
 
-                // install npm modules during init if source code zip doesn´t containt them
-                // check if package.json exists and node_modules don`t
-                if (fs.existsSync('package.json') && !fs.existsSync('./node_modules/')) {
-                    var package_json = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-                    if (package_json.hasOwnProperty('dependencies')) {
-                        if (Object.keys(package_json.dependencies).length > 0) {
-                            exec("npm install")
+
+                // check environment variable OW_ENABLE_INIT_INSTALL if we should do a 'npm install' to load not yet installed modules.
+                let enableInitInstall= !process.env.OW_ENABLE_INIT_INSTALL ? 'true' : process.env.OW_ENABLE_INIT_INSTALL;
+
+                if (enableInitInstall === 'true') {
+                    // install npm modules during init if source code zip doesn´t containt them
+                    // check if package.json exists and node_modules don`t
+                    if (fs.existsSync('package.json') && !fs.existsSync('./node_modules/')) {
+                        var package_json = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+                        if (package_json.hasOwnProperty('dependencies')) {
+                            if (Object.keys(package_json.dependencies).length > 0) {
+                                exec("npm install")
+                            }
                         }
                     }
                 }
+
+
 
                 //  The module to require.
                 let whatToRequire = index !== undefined ? path.join(moduleDir, index) : moduleDir;


### PR DESCRIPTION
- Use environment variable OW_ENABLE_INIT_INSTALL ('true', 'false') to decide if 'npm install' during init should be done or not. The default is 'true' (do an install). Reason to do not run the 'npm install' is that takes time and that production load may not want to install untested module versions.