### PR TITLE
update version of openwhisk package used by test actions

### DIFF
--- a/tests/dat/actions/nodejs-test/package.json
+++ b/tests/dat/actions/nodejs-test/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "openwhisk": "^2.0.0"
+    "openwhisk": "2.7.0"
   }
 }

--- a/tests/dat/docker/nodejs18docker/package.json
+++ b/tests/dat/docker/nodejs18docker/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "openwhisk": "2.0.0"
+    "openwhisk": "2.7.0"
   }
 }

--- a/tests/dat/docker/nodejs20docker/package.json
+++ b/tests/dat/docker/nodejs20docker/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "openwhisk": "2.0.0"
+    "openwhisk": "2.7.0"
   }
 }


### PR DESCRIPTION
Version must be 2.x because that's what the test is checking to make sure that the user can override the default, but we can at least make it the most recent 2.x release.